### PR TITLE
fix: Preserve word boundaries and JSON blocks in SSE streaming

### DIFF
--- a/scripts/test-raw-streaming.py
+++ b/scripts/test-raw-streaming.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Show raw SSE streaming output from the gateway without any parsing.
+This helps debug exactly what bytes are being sent over the wire.
+"""
+
+import asyncio
+import httpx
+import sys
+import os
+
+async def show_raw_stream(url: str, api_key: str, endpoint: str = "/api/v1/chat"):
+    """Show raw bytes from streaming endpoint."""
+    print(f"\n{'='*60}")
+    print(f"RAW STREAM from: {url}{endpoint}")
+    print('='*60)
+    
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json"
+    }
+    
+    payload = {
+        "message": "Count from 1 to 5 slowly",
+        "stream": True
+    }
+    
+    byte_count = 0
+    chunk_count = 0
+    
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            async with client.stream(
+                "POST",
+                f"{url}{endpoint}",
+                headers=headers,
+                json=payload
+            ) as response:
+                print(f"Status: {response.status_code}")
+                print(f"Headers:")
+                for k, v in response.headers.items():
+                    print(f"  {k}: {v}")
+                print("-" * 40)
+                
+                if response.status_code != 200:
+                    error_text = await response.aread()
+                    print(f"Error: {error_text.decode()}")
+                    return
+                
+                print("RAW BYTES (showing as UTF-8 with escape sequences):")
+                print("-" * 40)
+                
+                # Show raw bytes as they arrive
+                async for chunk in response.aiter_bytes():
+                    chunk_count += 1
+                    byte_count += len(chunk)
+                    
+                    # Decode to show human-readable form with escapes
+                    try:
+                        text = chunk.decode('utf-8')
+                        # Show with visible newlines and special chars
+                        display = repr(text)[1:-1]  # Remove quotes from repr
+                        print(f"[Chunk {chunk_count:3d}] {len(chunk):4d} bytes: {display}")
+                    except:
+                        # If not UTF-8, show hex
+                        print(f"[Chunk {chunk_count:3d}] {len(chunk):4d} bytes: {chunk.hex()}")
+                
+                print("-" * 40)
+                print(f"Total: {chunk_count} chunks, {byte_count} bytes")
+                
+        except Exception as e:
+            print(f"Error: {e}")
+
+async def show_with_line_boundaries(url: str, api_key: str, endpoint: str = "/api/v1/chat"):
+    """Show stream with line boundaries visible."""
+    print(f"\n{'='*60}")
+    print(f"LINE-BASED VIEW from: {url}{endpoint}")
+    print('='*60)
+    
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json"
+    }
+    
+    payload = {
+        "message": "Count from 1 to 5 slowly",
+        "stream": True
+    }
+    
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            async with client.stream(
+                "POST",
+                f"{url}{endpoint}",
+                headers=headers,
+                json=payload
+            ) as response:
+                if response.status_code != 200:
+                    error_text = await response.aread()
+                    print(f"Error: {error_text.decode()}")
+                    return
+                
+                print("LINES (with \\n markers):")
+                print("-" * 40)
+                
+                line_count = 0
+                buffer = ""
+                
+                # Accumulate and show lines
+                async for chunk in response.aiter_text():
+                    buffer += chunk
+                    
+                    # Show each complete line
+                    while '\n' in buffer:
+                        line, buffer = buffer.split('\n', 1)
+                        line_count += 1
+                        if line:
+                            print(f"[Line {line_count:3d}] {line}")
+                        else:
+                            print(f"[Line {line_count:3d}] <empty>")
+                
+                # Show any remaining buffer
+                if buffer:
+                    line_count += 1
+                    print(f"[Line {line_count:3d}] {buffer} (no newline)")
+                
+                print("-" * 40)
+                print(f"Total: {line_count} lines")
+                
+        except Exception as e:
+            print(f"Error: {e}")
+
+async def show_event_boundaries(url: str, api_key: str, endpoint: str = "/api/v1/chat"):
+    """Show SSE event boundaries (double newlines)."""
+    print(f"\n{'='*60}")
+    print(f"SSE EVENT BOUNDARIES from: {url}{endpoint}")
+    print('='*60)
+    
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json"
+    }
+    
+    payload = {
+        "message": "Count from 1 to 5 slowly",
+        "stream": True
+    }
+    
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            async with client.stream(
+                "POST",
+                f"{url}{endpoint}",
+                headers=headers,
+                json=payload
+            ) as response:
+                if response.status_code != 200:
+                    error_text = await response.aread()
+                    print(f"Error: {error_text.decode()}")
+                    return
+                
+                print("SSE EVENTS (split on \\n\\n):")
+                print("-" * 40)
+                
+                event_count = 0
+                buffer = ""
+                
+                # Accumulate and show events
+                async for chunk in response.aiter_text():
+                    buffer += chunk
+                    
+                    # Show each complete SSE event
+                    while '\n\n' in buffer:
+                        event, buffer = buffer.split('\n\n', 1)
+                        event_count += 1
+                        print(f"[Event {event_count:3d}]")
+                        for line in event.split('\n'):
+                            if line:
+                                print(f"  {line}")
+                            else:
+                                print(f"  <empty line>")
+                        print()
+                
+                # Show any remaining buffer
+                if buffer.strip():
+                    event_count += 1
+                    print(f"[Event {event_count:3d}] INCOMPLETE:")
+                    for line in buffer.split('\n'):
+                        if line:
+                            print(f"  {line}")
+                
+                print("-" * 40)
+                print(f"Total: {event_count} SSE events")
+                
+        except Exception as e:
+            print(f"Error: {e}")
+
+async def main():
+    """Run raw streaming tests."""
+    # Configuration
+    gateway_url = "http://localhost:8666"
+    api_key = os.getenv("API_KEY", "test-api-key")
+    
+    print("="*60)
+    print("RAW SSE STREAMING ANALYSIS")
+    print("="*60)
+    print(f"Gateway: {gateway_url}")
+    print(f"API Key: {api_key[:10]}..." if len(api_key) > 10 else api_key)
+    
+    # Test both endpoints
+    endpoints = [
+        "/api/v1/chat",      # Raw proxy
+        "/api/v0.3/chat"     # Clean format
+    ]
+    
+    for endpoint in endpoints:
+        # Show raw bytes
+        await show_raw_stream(gateway_url, api_key, endpoint)
+        
+        # Show line boundaries
+        await show_with_line_boundaries(gateway_url, api_key, endpoint)
+        
+        # Show SSE event boundaries
+        await show_event_boundaries(gateway_url, api_key, endpoint)
+        
+        print("\n" + "="*60 + "\n")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test-sse-streaming.py
+++ b/scripts/test-sse-streaming.py
@@ -124,9 +124,10 @@ async def test_streaming_endpoint(url: str, api_key: str, endpoint: str = "/api/
 
 async def main():
     """Run streaming tests."""
+    import os
     # Configuration
     gateway_url = "http://localhost:8666"
-    api_key = "test-api-key"  # Replace with actual key
+    api_key = os.getenv("API_KEY", "test-api-key")  # Get from environment
     
     print("SSE Streaming Token Boundary Test")
     print("=================================")

--- a/scripts/test-sse-streaming.py
+++ b/scripts/test-sse-streaming.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Test SSE streaming to verify token boundaries are preserved.
+
+This script tests both the raw gateway proxy and the v0.3 clean format
+to ensure SSE events and tokens are not split incorrectly.
+"""
+
+import asyncio
+import httpx
+import json
+import sys
+from typing import AsyncGenerator, Dict, Any
+
+async def parse_sse_stream(response: httpx.Response) -> AsyncGenerator[Dict[str, Any], None]:
+    """Parse SSE stream correctly, respecting event boundaries."""
+    buffer = ""
+    
+    async for chunk in response.aiter_text():
+        buffer += chunk
+        
+        # Process complete SSE events (separated by double newlines)
+        while "\n\n" in buffer:
+            event, buffer = buffer.split("\n\n", 1)
+            
+            if not event.strip():
+                continue
+            
+            # Parse the SSE event
+            if event.startswith("data: "):
+                data_str = event[6:].strip()
+                
+                if data_str == "[DONE]":
+                    print("Stream complete: [DONE]")
+                    return
+                
+                try:
+                    data = json.loads(data_str)
+                    yield data
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Failed to parse SSE data: {e}")
+                    print(f"Raw data: {data_str[:100]}")
+
+async def test_streaming_endpoint(url: str, api_key: str, endpoint: str = "/api/v1/chat"):
+    """Test a streaming endpoint."""
+    print(f"\n{'='*60}")
+    print(f"Testing: {url}{endpoint}")
+    print('='*60)
+    
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json"
+    }
+    
+    payload = {
+        "message": "Write a haiku about streaming data. Include some code.",
+        "stream": True
+    }
+    
+    tokens_received = []
+    event_count = 0
+    
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            async with client.stream(
+                "POST",
+                f"{url}{endpoint}",
+                headers=headers,
+                json=payload
+            ) as response:
+                print(f"Response status: {response.status_code}")
+                print(f"Content-Type: {response.headers.get('content-type', 'not set')}")
+                
+                if response.status_code != 200:
+                    error_text = await response.aread()
+                    print(f"Error response: {error_text.decode()}")
+                    return
+                
+                # Parse SSE events
+                async for event_data in parse_sse_stream(response):
+                    event_count += 1
+                    
+                    # Check event structure
+                    if "type" in event_data:
+                        event_type = event_data["type"]
+                        print(f"Event {event_count}: type={event_type}", end="")
+                        
+                        if event_type == "content" and "content" in event_data:
+                            content = event_data["content"]
+                            tokens_received.append(content)
+                            print(f" | content='{content}'")
+                        else:
+                            print(f" | data={event_data}")
+                    elif "choices" in event_data:
+                        # OpenAI format
+                        choices = event_data.get("choices", [])
+                        if choices and "delta" in choices[0]:
+                            content = choices[0]["delta"].get("content", "")
+                            if content:
+                                tokens_received.append(content)
+                                print(f"Event {event_count}: OpenAI format | content='{content}'")
+                    else:
+                        print(f"Event {event_count}: Unknown format | {event_data}")
+                
+                print(f"\n✅ Successfully received {event_count} events")
+                print(f"✅ Total tokens/chunks: {len(tokens_received)}")
+                
+                # Reconstruct the full message
+                full_message = "".join(tokens_received)
+                print(f"\nReconstructed message ({len(full_message)} chars):")
+                print("-" * 40)
+                print(full_message)
+                print("-" * 40)
+                
+                # Check for common issues
+                if "\n" in "".join(tokens_received[:5]):
+                    print("⚠️  Warning: Early tokens contain newlines - might indicate splitting issues")
+                
+                return True
+                
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            return False
+
+async def main():
+    """Run streaming tests."""
+    # Configuration
+    gateway_url = "http://localhost:8666"
+    api_key = "test-api-key"  # Replace with actual key
+    
+    print("SSE Streaming Token Boundary Test")
+    print("=================================")
+    
+    # Test regular gateway proxy (raw pass-through)
+    success1 = await test_streaming_endpoint(gateway_url, api_key, "/api/v1/chat")
+    
+    # Test v0.3 clean format (with conversion)
+    success2 = await test_streaming_endpoint(gateway_url, api_key, "/api/v0.3/chat")
+    
+    # Summary
+    print(f"\n{'='*60}")
+    print("Test Summary:")
+    print(f"  Gateway raw proxy: {'✅ PASSED' if success1 else '❌ FAILED'}")
+    print(f"  v0.3 clean format: {'✅ PASSED' if success2 else '❌ FAILED'}")
+    print('='*60)
+    
+    return 0 if (success1 and success2) else 1
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- Fixed gateway to use raw byte pass-through for SSE streaming instead of line-based splitting
- Fixed chat service to respect word boundaries when chunking responses
- Added JSON block preservation to keep structured data intact during streaming

## Problem
The gateway was using `aiter_lines()` which split SSE events on newlines, breaking the SSE format. Additionally, the chat service was using arbitrary character-based chunking (20 chars) which resulted in words being split mid-token (e.g., "fr"/"om", "tog"/"ether").

## Solution
1. **Gateway**: Changed from `response.aiter_lines()` to `response.aiter_bytes()` for raw pass-through
2. **Chat Service**: Implemented `split_on_word_boundaries()` function that:
   - Respects word boundaries (splits on whitespace)
   - Preserves complete JSON blocks using regex pattern matching
   - Maintains reasonable chunk sizes while preventing token splitting

## Test Results
Deployed and tested on dev environment:
- ✅ SSE events maintain proper `data:` prefix and `\n\n` boundaries
- ✅ Words are no longer split mid-token
- ✅ JSON blocks remain intact
- ✅ Streaming performance unchanged

## Files Changed
- `app/gateway/main.py`: Raw byte streaming pass-through
- `app/services/chat/unified_chat.py`: Word boundary aware chunking

🤖 Generated with [Claude Code](https://claude.ai/code)